### PR TITLE
Replace Bearly code interpreter with e2b

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The oracle currently supports calling the following, all of which is also suppor
 
 * LLMs from OpenAI and Groq
 * Image generation with OpenAI's DALL-E
-* Code execution via Bearly's code interpreter API
+* Code execution via E2B's code interpreter API
 * Web search via Serper API
 
 See details of supported tools in the [oracle reference](https://docs.galadriel.com/reference/overview).

--- a/admin/client.py
+++ b/admin/client.py
@@ -14,7 +14,7 @@ ACTION_SIGN_MESSAGE = "sign_message"
 ACTION_SEND_SECRETS = "send_secrets"
 ACTION_PS = "ps"
 ACTION_CHECK_OPENAI_PROXY = "check_openai_proxy"
-ACTION_CHECK_E2B_PROXY = "check_e2b_proxy"
+ACTION_DNS = "dns"
 
 
 def save_attestation_b64(attestation_b64):
@@ -65,6 +65,17 @@ def _action_sign_message(s, message):
     print("signature_b64:", signature_b64)
 
 
+def _action_dns(s, hostname):
+    s.send(str.encode(json.dumps({
+        "action": ACTION_DNS,
+        "hostname": hostname
+    })))
+    # receive the plaintext from the server and print it to console
+    response = s.recv(65536)
+    response_decoded = response.decode()
+    print("response_decoded:", response_decoded)
+
+
 def get_gcp_creds():
     with open("sidekik.json", "r") as file:
         return file.read()
@@ -102,7 +113,7 @@ def _get_cid():
     return enclave_cid
 
 
-def main(cid: str, action: str, message: str = None, until_success: bool = False):
+def main(cid: str, action: str, message: str = None, hostname: str = None, until_success: bool = False):
     while True:
         try:
             if not cid:
@@ -127,6 +138,8 @@ def main(cid: str, action: str, message: str = None, until_success: bool = False
                 _action_ps(s)
             elif action == ACTION_CHECK_OPENAI_PROXY:
                 _action_check_openai_proxy(s)
+            elif action == ACTION_DNS:
+                _action_dns(s, hostname)
 
             # close the connection
             s.close()
@@ -157,6 +170,7 @@ if __name__ == '__main__':
             ACTION_SEND_SECRETS,
             ACTION_PS,
             ACTION_CHECK_OPENAI_PROXY,
+            ACTION_DNS,
         ],
         help="action to run"
     )
@@ -166,6 +180,11 @@ if __name__ == '__main__':
         help="message to sign in the enclave"
     )
     parser.add_argument(
+        "--hostname",
+        type=str,
+        help="hostname to resolve in the enclave"
+    )
+    parser.add_argument(
         "--until_success",
         type=bool,
         help="retries until success",
@@ -173,4 +192,4 @@ if __name__ == '__main__':
     )
 
     args = parser.parse_args()
-    main(args.cid, args.action, args.message, args.until_success)
+    main(args.cid, args.action, args.message, args.hostname, args.until_success)

--- a/admin/client.py
+++ b/admin/client.py
@@ -13,6 +13,8 @@ ACTION_GET_ATTESTATION = "get_attestation_doc"
 ACTION_SIGN_MESSAGE = "sign_message"
 ACTION_SEND_SECRETS = "send_secrets"
 ACTION_PS = "ps"
+ACTION_CHECK_OPENAI_PROXY = "check_openai_proxy"
+ACTION_CHECK_E2B_PROXY = "check_e2b_proxy"
 
 
 def save_attestation_b64(attestation_b64):
@@ -23,6 +25,15 @@ def save_attestation_b64(attestation_b64):
 def _action_ping(s):
     s.send(str.encode(json.dumps({
         "action": ACTION_PING
+    })))
+    response = s.recv(65536)
+    response_decoded = response.decode()
+    print("response_decoded:", response_decoded)
+
+
+def _action_check_openai_proxy(s):
+    s.send(str.encode(json.dumps({
+        "action": ACTION_CHECK_OPENAI_PROXY
     })))
     response = s.recv(65536)
     response_decoded = response.decode()
@@ -114,6 +125,8 @@ def main(cid: str, action: str, message: str = None, until_success: bool = False
                 _action_send_secrets(s)
             elif action == ACTION_PS:
                 _action_ps(s)
+            elif action == ACTION_CHECK_OPENAI_PROXY:
+                _action_check_openai_proxy(s)
 
             # close the connection
             s.close()
@@ -142,7 +155,8 @@ if __name__ == '__main__':
             ACTION_GET_ATTESTATION,
             ACTION_SIGN_MESSAGE,
             ACTION_SEND_SECRETS,
-            ACTION_PS
+            ACTION_PS,
+            ACTION_CHECK_OPENAI_PROXY,
         ],
         help="action to run"
     )

--- a/admin/settings.py
+++ b/admin/settings.py
@@ -16,7 +16,7 @@ ORACLE_ADDRESS = os.getenv("ORACLE_ADDRESS", "")
 ORACLE_ABI_PATH = os.getenv("ORACLE_ABI_PATH", "")
 
 GCS_BUCKET_NAME = os.getenv("GCS_BUCKET_NAME", "galadriel-assets")
-BEARLY_API_KEY = os.getenv("BEARLY_API_KEY", "")
+E2B_API_KEY = os.getenv("E2B_API_KEY", "")
 GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
 
 PINATA_API_JWT = os.getenv("PINATA_API_JWT", "")
@@ -33,7 +33,7 @@ def get_dot_env() -> Dict:
         "ORACLE_ADDRESS": ORACLE_ADDRESS,
         "ORACLE_ABI_PATH": "/app/oracles/abi/ChatOracle.json",
         "GCS_BUCKET_NAME": GCS_BUCKET_NAME,
-        "BEARLY_API_KEY": BEARLY_API_KEY,
+        "E2B_API_KEY": E2B_API_KEY,
         "GROQ_API_KEY": GROQ_API_KEY,
         "PINATA_API_JWT": PINATA_API_JWT,
         "PINATA_GATEWAY_TOKEN": PINATA_GATEWAY_TOKEN,

--- a/enclave/Dockerfile
+++ b/enclave/Dockerfile
@@ -3,7 +3,7 @@ FROM amazonlinux:2023.3.20240219.0
 # Install python for running the server and net-tools for modifying network config
 RUN yum update -y
 RUN yum groupinstall "Development Tools" -y
-RUN yum install openssl-devel bzip2-devel libffi-devel wget net-tools git iproute -y
+RUN yum install openssl-devel bzip2-devel libffi-devel wget net-tools git iproute dnsmasq -y
 
 
 WORKDIR /tmp
@@ -37,6 +37,8 @@ COPY oracles/oracles ./oracles
 COPY proxy_checks ./proxy_checks/
 COPY check_proxies.py ./
 
+COPY dnsmasq.conf /etc/dnsmasq.conf
+
 RUN chmod +x run.sh
 
-CMD ["/app/run.sh"]
+CMD ["sh", "-c", "dnsmasq --no-daemon & /app/run.sh"]

--- a/enclave/Dockerfile
+++ b/enclave/Dockerfile
@@ -4,7 +4,8 @@ FROM amazonlinux:2023.3.20240219.0
 RUN yum update -y
 RUN yum groupinstall "Development Tools" -y
 RUN yum install openssl-devel bzip2-devel libffi-devel wget net-tools git iproute dnsmasq -y
-
+# stop DNS service (just in case)
+RUN systemctl disable systemd-resolved
 
 WORKDIR /tmp
 RUN wget https://www.python.org/ftp/python/3.10.4/Python-3.10.4.tgz

--- a/enclave/Dockerfile
+++ b/enclave/Dockerfile
@@ -41,4 +41,4 @@ COPY dnsmasq.conf /etc/dnsmasq.conf
 
 RUN chmod +x run.sh
 
-CMD ["sh", "-c", "dnsmasq --no-daemon & /app/run.sh"]
+CMD ["/app/run.sh"]

--- a/enclave/check_proxies.py
+++ b/enclave/check_proxies.py
@@ -7,7 +7,7 @@ from proxy_checks import openai_call
 
 async def main():
     print("\n=== OPENAI call start ===")
-    openai_is_success, openai_error = await openai_call.execute()
+    openai_is_success, openai_error = openai_call.execute()
     print("=== OPENAI Call done ===")
     print("\n=== GoogleSerper call start ===")
     serper_is_success, serper_error = await google_serper_call.execute()

--- a/enclave/dnsmasq.conf
+++ b/enclave/dnsmasq.conf
@@ -8,4 +8,4 @@ bogus-priv
 listen-address=127.0.0.1
 
 # Address mapping for all subdomains of eb2.dev to localhost
-address=/eb2.dev/127.0.0.1
+address=/e2b.dev/127.0.0.1

--- a/enclave/dnsmasq.conf
+++ b/enclave/dnsmasq.conf
@@ -1,0 +1,11 @@
+# Never forward plain names (without a dot or domain part)
+domain-needed
+
+# Never forward addresses in the non-routed address spaces
+bogus-priv
+
+# Listen on all interfaces that Docker can use within the enclave
+listen-address=127.0.0.1
+
+# Address mapping for all subdomains of eb2.dev to localhost
+address=/eb2.dev/127.0.0.1

--- a/enclave/proxy_checks/openai_call.py
+++ b/enclave/proxy_checks/openai_call.py
@@ -1,4 +1,4 @@
-async def execute() -> (bool, str):
+def execute() -> (bool, str):
     try:
         import settings
         import requests

--- a/enclave/requirements.txt
+++ b/enclave/requirements.txt
@@ -8,3 +8,4 @@ psutil==5.9.8
 pytest==8.1.1
 pytest-cov==4.1.0
 groq==0.4.2
+e2b_code_interpreter==0.0.5

--- a/enclave/run.sh
+++ b/enclave/run.sh
@@ -21,7 +21,8 @@ echo "127.0.0.1   api.groq.com" >> /etc/hosts
 echo "127.0.0.1   galadriel.mypinata.cloud" >> /etc/hosts
 echo "127.0.0.1   api.pinata.cloud" >> /etc/hosts
 
-echo "nameserver 127.0.0.1" >> /etc/resolv.conf
+mkdir -p /run/resolvconf
+echo "nameserver 127.0.0.1" > /run/resolvconf/resolv.conf
 
 # run TLS traffic forwarder
 python3.10 /app/traffic_forwarder.py 127.0.0.1 443 &

--- a/enclave/run.sh
+++ b/enclave/run.sh
@@ -5,6 +5,10 @@ ip addr add 127.0.0.1/32 dev lo
 
 ip link set dev lo up
 
+# Starting DNSMasq
+echo "Starting DNSMasq..."
+dnsmasq --no-daemon &
+
 # Add a hosts record, pointing target site calls to local loopback
 echo "127.0.0.1   api.openai.com" >> /etc/hosts
 echo "127.0.0.1   google.serper.dev" >> /etc/hosts
@@ -17,6 +21,9 @@ echo "127.0.0.1   api.groq.com" >> /etc/hosts
 echo "127.0.0.1   galadriel.mypinata.cloud" >> /etc/hosts
 echo "127.0.0.1   api.pinata.cloud" >> /etc/hosts
 
+echo "nameserver 127.0.0.1" >> /etc/resolv.conf
+
+# run TLS traffic forwarder
 python3.10 /app/traffic_forwarder.py 127.0.0.1 443 &
 
 # sleep so there is time to open enclave debug logs before the server potentially crashes

--- a/enclave/run_proxies.sh
+++ b/enclave/run_proxies.sh
@@ -10,7 +10,7 @@ nohup vsock-proxy 8005 storage.googleapis.com 443 \
   --config vsock/vsock_proxy_google_storage.yaml &> vsock_proxy_google_storage.log &
 nohup vsock-proxy 8006 oauth2.googleapis.com 443 \
   --config vsock/vsock_proxy_google_oauth2.yaml &> vsock_proxy_google_oauth2.log &
-nohup vsock-proxy 8007 api.e2b.dev 8888 \
+nohup vsock-proxy 8007 api.e2b.dev 443 \
   --config vsock/vsock_proxy_e2b.yaml &> vsock_proxy_e2b.log &
 nohup vsock-proxy 8008 api.groq.com 443 \
   --config vsock/vsock_proxy_groq.yaml &> vsock_proxy_groq.log &

--- a/enclave/run_proxies.sh
+++ b/enclave/run_proxies.sh
@@ -10,8 +10,8 @@ nohup vsock-proxy 8005 storage.googleapis.com 443 \
   --config vsock/vsock_proxy_google_storage.yaml &> vsock_proxy_google_storage.log &
 nohup vsock-proxy 8006 oauth2.googleapis.com 443 \
   --config vsock/vsock_proxy_google_oauth2.yaml &> vsock_proxy_google_oauth2.log &
-nohup vsock-proxy 8007 exec.bearly.ai 443 \
-  --config vsock/vsock_proxy_bearly.yaml &> vsock_proxy_bearly.log &
+nohup vsock-proxy 8007 api.e2b.dev 8888 \
+  --config vsock/vsock_proxy_e2b.yaml &> vsock_proxy_e2b.log &
 nohup vsock-proxy 8008 api.groq.com 443 \
   --config vsock/vsock_proxy_groq.yaml &> vsock_proxy_groq.log &
 nohup vsock-proxy 8009 galadriel.mypinata.cloud 443 \

--- a/enclave/run_proxies.sh
+++ b/enclave/run_proxies.sh
@@ -1,20 +1,20 @@
 nohup vsock-proxy 8001 api.openai.com 443 \
-  --config vsock/vsock_proxy_openai.yaml &> vsock_proxy_openai.log &
+  --config vsock/vsock_proxy_openai.yaml -w 20 &> vsock_proxy_openai.log &
 nohup vsock-proxy 8002 google.serper.dev 443 \
-  --config vsock/vsock_proxy_serper.yaml &> vsock_proxy_serper.log &
+  --config vsock/vsock_proxy_serper.yaml -w 20 &> vsock_proxy_serper.log &
 nohup vsock-proxy 8003 devnet.galadriel.com 443 \
-  --config vsock/vsock_proxy_galadriel.yaml &> vsock_proxy_galadriel.log &
+  --config vsock/vsock_proxy_galadriel.yaml -w 20 &> vsock_proxy_galadriel.log &
 nohup vsock-proxy 8004 oaidalleapiprodscus.blob.core.windows.net 443 \
-  --config vsock/vsock_proxy_windows.yaml &> vsock_proxy_windows.log &
+  --config vsock/vsock_proxy_windows.yaml -w 20 &> vsock_proxy_windows.log &
 nohup vsock-proxy 8005 storage.googleapis.com 443 \
-  --config vsock/vsock_proxy_google_storage.yaml &> vsock_proxy_google_storage.log &
+  --config vsock/vsock_proxy_google_storage.yaml -w 20 &> vsock_proxy_google_storage.log &
 nohup vsock-proxy 8006 oauth2.googleapis.com 443 \
-  --config vsock/vsock_proxy_google_oauth2.yaml &> vsock_proxy_google_oauth2.log &
+  --config vsock/vsock_proxy_google_oauth2.yaml -w 20 &> vsock_proxy_google_oauth2.log &
 nohup vsock-proxy 8007 api.e2b.dev 443 \
-  --config vsock/vsock_proxy_e2b.yaml &> vsock_proxy_e2b.log &
+  --config vsock/vsock_proxy_e2b.yaml -w 20 &> vsock_proxy_e2b.log &
 nohup vsock-proxy 8008 api.groq.com 443 \
-  --config vsock/vsock_proxy_groq.yaml &> vsock_proxy_groq.log &
+  --config vsock/vsock_proxy_groq.yaml -w 20 &> vsock_proxy_groq.log &
 nohup vsock-proxy 8009 galadriel.mypinata.cloud 443 \
-  --config vsock/vsock_proxy_ipfs.yaml &> vsock_proxy_ipfs.log &
+  --config vsock/vsock_proxy_ipfs.yaml -w 20 &> vsock_proxy_ipfs.log &
 nohup vsock-proxy 8010 api.pinata.cloud 443 \
-  --config vsock/vsock_proxy_pinata.yaml &> vsock_proxy_pinata.log &
+  --config vsock/vsock_proxy_pinata.yaml -w 20 &> vsock_proxy_pinata.log &

--- a/enclave/server.py
+++ b/enclave/server.py
@@ -5,6 +5,7 @@ import base64
 import psutil 
 from NsmUtil import NSMUtil
 import key_manager
+from proxy_checks import openai_call
 
 
 def main():
@@ -38,6 +39,13 @@ def main():
         if request["action"] == "ping":
             response = json.dumps({
                 "ping": "pong"
+            })
+            client_connection.send(str.encode(response))
+        elif request["action"] == "check_openai_proxy":
+            openai_is_success, openai_error = openai_call.execute()
+            response = json.dumps({
+                "success": openai_is_success,
+                "error": openai_error
             })
             client_connection.send(str.encode(response))
         elif request["action"] == "get_attestation_doc":

--- a/enclave/server.py
+++ b/enclave/server.py
@@ -80,6 +80,20 @@ def main():
                 client_connection.send(str.encode(json.dumps({
                     "exception": str(exc)
                 })))
+        elif request["action"] == "dns":
+            hostname = request["hostname"]
+            try:
+                ip_address = socket.gethostbyname(hostname)
+                request = json.dumps({
+                    "ip_address": ip_address,
+                    "error": ""
+                })
+            except socket.error as e:
+                request = json.dumps({
+                    "ip_address": "",
+                    "error": str(e)
+                })
+            client_connection.send(str.encode(request))
         elif request["action"] == "ps":
             cpu_usage = psutil.cpu_percent(percpu=True)
             memory_usage = psutil.virtual_memory()

--- a/enclave/traffic_forwarder.py
+++ b/enclave/traffic_forwarder.py
@@ -12,7 +12,7 @@ REMOTE_PORT_GALADRIEL = 8003
 REMOTE_PORT_WINDOWS = 8004
 REMOTE_PORT_GOOGLE_STORAGE = 8005
 REMOTE_PORT_GOOGLE_OAUTH2 = 8006
-REMOTE_PORT_BEARLY = 8007
+REMOTE_PORT_E2B = 8007
 REMOTE_PORT_GROQ = 8008
 REMOTE_PORT_IPFS = 8009
 REMOTE_PORT_PINATA = 8010
@@ -24,7 +24,7 @@ REMOTE_PORTS = {
     "oaidalleapiprodscus.blob.core.windows.net": REMOTE_PORT_WINDOWS,
     "storage.googleapis.com": REMOTE_PORT_GOOGLE_STORAGE,
     "oauth2.googleapis.com": REMOTE_PORT_GOOGLE_OAUTH2,
-    "exec.bearly.ai": REMOTE_PORT_BEARLY,
+    "e2b.dev": REMOTE_PORT_E2B,
     "api.groq.com": REMOTE_PORT_GROQ,
     "galadriel.mypinata.cloud": REMOTE_PORT_IPFS,
     "api.pinata.cloud": REMOTE_PORT_PINATA,

--- a/enclave/vsock/vsock_proxy_bearly.yaml
+++ b/enclave/vsock/vsock_proxy_bearly.yaml
@@ -1,2 +1,0 @@
-allowlist:
-  - { address: exec.bearly.ai, port: 443 }

--- a/enclave/vsock/vsock_proxy_e2b.yaml
+++ b/enclave/vsock/vsock_proxy_e2b.yaml
@@ -1,0 +1,2 @@
+allowlist:
+  - { address: api.e2b.dev, port: 443 }


### PR DESCRIPTION
- Removed Bearly AI proxying
- Added e2b proxying:
  -  added `dnsmasq` server to support wildcard subdomains
- increased number of vsock-proxy workers per proxied destination from default 4 to 20
- added extra client actions:
  - `check_openai_proxy` checks connection to openai
  - `dns` resolves `hostname` inside the enclave